### PR TITLE
Update External DNS version from 6.20.4 to 6.21.0

### DIFF
--- a/dns/external-dns/Chart.yaml
+++ b/dns/external-dns/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: This Chart deploys external-dns.
 dependencies:
   - name: external-dns
-    version: 6.20.4
+    version: 6.21.0
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned two differences
	        |___/
	
	(root level)
	+ one map entry added:
	  ## @param ingressClassFilters Filter sources managed by external-dns via IngressClass (optional)
	  ##
	  ingressClassFilters: []
	  
	
	
	image.tag
	  ± value change
	    - 0.13.4-debian-11-r19
	    + 0.13.5-debian-11-r55